### PR TITLE
Change URL for one-time code

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -66,7 +66,7 @@ func AuthHttpCtx(reAuth, nonInteractive bool) *transport.HttpClientCtx {
 
 func readCode() string {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/desktop/connect): ")
+	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/browser/connect): ")
 	code, _ := reader.ReadString('\n')
 
 	code = strings.TrimSuffix(code, "\n")

--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -47,7 +47,7 @@ The first time you run it, it will ask you to go to `https://my.remarkable.com/`
 You will see a prompt like this where you just need to introduce the activation code.
 
 ```bash
-Enter one-time code (go to https://my.remarkable.com/device/desktop/connect):
+Enter one-time code (go to https://my.remarkable.com/device/browser/connect):
 ```
 
 If everything goes OK, you wil have access to the shell:


### PR DESCRIPTION
This updates the URL for fetching a one-time code. The desktop one is unreliable but the browser one seems to work.