### PR TITLE
feat: Add update command to overwrite existing files in cloud

### DIFF
--- a/shell/put.go
+++ b/shell/put.go
@@ -8,6 +8,43 @@ import (
 	"github.com/juruen/rmapi/util"
 )
 
+func updateCmd(ctx *ShellCtxt) *ishell.Cmd {
+	return &ishell.Cmd{
+		Name:      "update",
+		Help:      "update/overwrite an existing document in cloud",
+		Completer: createFsEntryCompleter(),
+		Func: func(c *ishell.Context) {
+			if len(c.Args) == 0 {
+				c.Err(errors.New("missing source file"))
+				return
+			}
+
+			srcName := c.Args[0]
+			node := ctx.node
+			var err error
+
+			if len(c.Args) == 2 {
+				node, err = ctx.api.Filetree().NodeByPath(c.Args[1], ctx.node)
+				if err != nil || node.IsFile() {
+					c.Err(errors.New("directory doesn't exist"))
+					return
+				}
+			}
+
+			c.Printf("updating: [%s]...", srcName)
+			dstDir := node.Id()
+			document, err := ctx.api.UploadDocument(dstDir, srcName, true)
+			if err != nil {
+				c.Err(fmt.Errorf("Failed to update file [%s] %v", srcName, err))
+				return
+			}
+
+			c.Println("OK")
+			ctx.api.Filetree().AddDocument(document)
+		},
+	}
+}
+
 func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
 		Name:      "put",
@@ -20,7 +57,6 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 			}
 
 			srcName := c.Args[0]
-
 			docName, _ := util.DocPathToName(srcName)
 
 			node := ctx.node

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -62,6 +62,7 @@ func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
 	shell.AddCmd(rmCmd(ctx))
 	shell.AddCmd(mvCmd(ctx))
 	shell.AddCmd(putCmd(ctx))
+	shell.AddCmd(updateCmd(ctx))
 	shell.AddCmd(mputCmd(ctx))
 	shell.AddCmd(versionCmd(ctx))
 	shell.AddCmd(statCmd(ctx))


### PR DESCRIPTION
I have a use case that involves updating my journal PDF with daily calendar items, so I wanted to be able to force upload a file. I call the new function "update". 