### PR TITLE
feat: added coverpage, force, content-only flags to put

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ You can also specify the destination directory:
 put book.pdf /books
 ```
 
+### Upload flags
+
+- `--force`: Completely replace an existing document (removes all annotations and metadata)
+- `--content-only`: Replace only the PDF content while preserving annotations and metadata
+- `--coverpage=<0|1>`: Set coverpage (0 to disable, 1 to set first page as cover)
+
+Examples:
+
+```bash
+# Upload new file (fails if already exists)
+put document.pdf
+
+# Force overwrite existing document completely
+put --force document.pdf
+
+# Replace PDF content but keep annotations
+put --content-only document.pdf
+
+# Upload with coverpage set to first page
+put --coverpage=1 document.pdf
+
+# Replace PDF content in specific directory
+put --content-only document.pdf /target-directory
+
+# Upload to specific directory with force
+put --force document.pdf /reports
+```
+
+**Note**: `--force` and `--content-only` are mutually exclusive. The `--coverpage` flag can be combined with either. If the target document doesn't exist, all flags will create a new document.
+
 ## Recursively upload directories and files
 
 Use `mput path_to_dir` to recursively upload all the local files to that directory.

--- a/api/api.go
+++ b/api/api.go
@@ -18,7 +18,8 @@ type ApiCtx interface {
 	Filetree() *filetree.FileTreeCtx
 	FetchDocument(docId, dstPath string) error
 	CreateDir(parentId, name string, notify bool) (*model.Document, error)
-	UploadDocument(parentId string, sourceDocPath string, notify bool) (*model.Document, error)
+	UploadDocument(parentId string, sourceDocPath string, notify bool, coverpage *int) (*model.Document, error)
+	ReplaceDocumentFile(docId, sourceDocPath string, notify bool) error
 	MoveEntry(src, dstDir *model.Node, name string) (*model.Node, error)
 	DeleteEntry(node *model.Node, recursive, notify bool) error
 	SyncComplete() error

--- a/api/sync15/apictx.go
+++ b/api/sync15/apictx.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -144,7 +145,7 @@ func (ctx *ApiCtx) CreateDir(parentId, name string, notify bool) (*model.Documen
 	}
 	files.AddMap(objectName, filePath, archive.MetadataExt)
 
-	objectName, filePath, err = archive.CreateContent(id, "", tmpDir, nil)
+	objectName, filePath, err = archive.CreateContent(id, "", tmpDir, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +335,7 @@ func (ctx *ApiCtx) MoveEntry(src, dstDir *model.Node, name string) (*model.Node,
 }
 
 // UploadDocument uploads a local document given by sourceDocPath under the parentId directory
-func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string, notify bool) (*model.Document, error) {
+func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string, notify bool, coverpage *int) (*model.Document, error) {
 	//TODO: overwrite file
 	name, ext := util.DocPathToName(sourceDocPath)
 
@@ -355,7 +356,7 @@ func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string, notify 
 
 	defer os.RemoveAll(tmpDir)
 
-	docFiles, id, err := archive.Prepare(name, parentId, sourceDocPath, ext, tmpDir)
+	docFiles, id, err := archive.Prepare(name, parentId, sourceDocPath, ext, tmpDir, coverpage)
 	if err != nil {
 		return nil, err
 	}
@@ -407,6 +408,62 @@ func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string, notify 
 	}
 
 	return doc.ToDocument(), nil
+}
+
+// ReplaceDocumentFile replaces the main document file (e.g. PDF) of an existing document
+// identified by docId with the local file given by sourceDocPath. Metadata and annotations
+// remain untouched.
+func (ctx *ApiCtx) ReplaceDocumentFile(docId, sourceDocPath string, notify bool) error {
+	_, ext := util.DocPathToName(sourceDocPath)
+	return Sync(ctx.blobStorage, ctx.hashTree, func(t *HashTree) error {
+		doc, err := t.FindDoc(docId)
+		if err != nil {
+			return err
+		}
+
+		var fileEntry *Entry
+		for _, f := range doc.Files {
+			if strings.HasSuffix(f.DocumentID, "."+ext) {
+				fileEntry = f
+				break
+			}
+		}
+		if fileEntry == nil {
+			return fmt.Errorf("document does not contain .%s", ext)
+		}
+
+		hash, size, err := FileHashAndSize(sourceDocPath)
+		if err != nil {
+			return err
+		}
+		hashStr := hex.EncodeToString(hash)
+
+		r, err := os.Open(sourceDocPath)
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+
+		if err := ctx.blobStorage.UploadBlob(hashStr, fileEntry.DocumentID, r); err != nil {
+			return err
+		}
+
+		fileEntry.Hash = hashStr
+		fileEntry.Size = size
+
+		if err := doc.Rehash(); err != nil {
+			return err
+		}
+		if err := t.Rehash(); err != nil {
+			return err
+		}
+
+		indexReader, err := doc.IndexReader()
+		if err != nil {
+			return err
+		}
+		return ctx.blobStorage.UploadBlob(doc.Hash, addExt(doc.DocumentID, archive.DocSchemaExt), indexReader)
+	}, notify)
 }
 
 // DocumentsFileTree reads your remote documents and builds a file tree

--- a/archive/blob.go
+++ b/archive/blob.go
@@ -47,7 +47,7 @@ func (d *DocumentFiles) AddMap(name, filepath string, filetype RmExt) {
 }
 
 // Prepare prepares a file for uploading (creates needed temp files or unpacks a zip)
-func Prepare(name, parentId, sourceDocPath, ext, tmpDir string) (files *DocumentFiles, id string, err error) {
+func Prepare(name, parentId, sourceDocPath, ext, tmpDir string, coverpage *int) (files *DocumentFiles, id string, err error) {
 	files = &DocumentFiles{}
 	if ext == util.ZIP || ext == util.RMDOC {
 		var metadataPath string
@@ -91,7 +91,7 @@ func Prepare(name, parentId, sourceDocPath, ext, tmpDir string) (files *Document
 		}
 		files.AddMap(objectName, filePath, MetadataExt)
 
-		objectName, filePath, err = CreateContent(id, doctype, tmpDir, pageIds)
+		objectName, filePath, err = CreateContent(id, doctype, tmpDir, pageIds, coverpage)
 		if err != nil {
 			return
 		}

--- a/archive/file.go
+++ b/archive/file.go
@@ -106,6 +106,7 @@ type Content struct {
 	Tags           []string `json:"pageTags"`
 	RedirectionMap []int    `json:"redirectionPageMap"`
 	TextScale      int      `json:"textScale"`
+	CoverPageNumber *int    `json:"coverPageNumber,omitempty"`
 
 	Transform Transform `json:"transform"`
 }

--- a/archive/zipdoc.go
+++ b/archive/zipdoc.go
@@ -144,7 +144,7 @@ func CreateZipDocument(id, srcPath string) (zipPath string, err error) {
 		return
 	}
 
-	c, err := createZipContent(fileType, pages)
+	c, err := createZipContent(fileType, pages, nil)
 	if err != nil {
 		return
 	}
@@ -179,7 +179,7 @@ func CreateZipDirectory(id string) (string, error) {
 	return tmp.Name(), nil
 }
 
-func createZipContent(ext string, pageIDs []string) (string, error) {
+func createZipContent(ext string, pageIDs []string, coverpage *int) (string, error) {
 	c := Content{
 		DummyDocument: false,
 		ExtraMetadata: ExtraMetadata{
@@ -205,6 +205,7 @@ func createZipContent(ext string, pageIDs []string) (string, error) {
 			M33: 1,
 		},
 		Pages: pageIDs,
+		CoverPageNumber: coverpage,
 	}
 
 	cstring, err := json.Marshal(c)
@@ -217,13 +218,13 @@ func createZipContent(ext string, pageIDs []string) (string, error) {
 	return string(cstring), nil
 }
 
-func CreateContent(id, ext, fpath string, pageIds []string) (fileName, filePath string, err error) {
+func CreateContent(id, ext, fpath string, pageIds []string, coverpage *int) (fileName, filePath string, err error) {
 	fileName = id + "." + string(ContentExt)
 	filePath = path.Join(fpath, fileName)
 	content := "{}"
 
 	if ext != "" {
-		content, err = createZipContent(ext, pageIds)
+		content, err = createZipContent(ext, pageIds, coverpage)
 		if err != nil {
 			return
 		}

--- a/shell/mput.go
+++ b/shell/mput.go
@@ -213,7 +213,7 @@ func putFilesAndDirs(pCtx *ShellCtxt, pC *ishell.Context, localDir string, depth
 				pC.Printf("uploading: [%s]...", name)
 
 				fullName := path.Join(localDir, name)
-				doc, err := pCtx.api.UploadDocument(pCtx.node.Id(), fullName, false)
+				doc, err := pCtx.api.UploadDocument(pCtx.node.Id(), fullName, false, nil)
 
 				if err != nil {
 					pC.Err(fmt.Errorf("failed to upload file '%s', %v", name, err))

--- a/shell/put.go
+++ b/shell/put.go
@@ -6,86 +6,175 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/juruen/rmapi/util"
+	"github.com/ogier/pflag"
 )
-
-func updateCmd(ctx *ShellCtxt) *ishell.Cmd {
-	return &ishell.Cmd{
-		Name:      "update",
-		Help:      "update/overwrite an existing document in cloud",
-		Completer: createFsEntryCompleter(),
-		Func: func(c *ishell.Context) {
-			if len(c.Args) == 0 {
-				c.Err(errors.New("missing source file"))
-				return
-			}
-
-			srcName := c.Args[0]
-			node := ctx.node
-			var err error
-
-			if len(c.Args) == 2 {
-				node, err = ctx.api.Filetree().NodeByPath(c.Args[1], ctx.node)
-				if err != nil || node.IsFile() {
-					c.Err(errors.New("directory doesn't exist"))
-					return
-				}
-			}
-
-			c.Printf("updating: [%s]...", srcName)
-			dstDir := node.Id()
-			document, err := ctx.api.UploadDocument(dstDir, srcName, true)
-			if err != nil {
-				c.Err(fmt.Errorf("Failed to update file [%s] %v", srcName, err))
-				return
-			}
-
-			c.Println("OK")
-			ctx.api.Filetree().AddDocument(document)
-		},
-	}
-}
 
 func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
 		Name:      "put",
 		Help:      "copy a local document to cloud",
 		Completer: createFsEntryCompleter(),
+		LongHelp: `Usage: put [options] <local_file> [remote_directory]
+
+Options:
+  --force              Overwrite existing file (recreates document)
+  --content-only       Replace PDF content only (preserves document metadata)
+  --coverpage=<0|1>    Set coverpage (0 to disable, 1 to set first page as cover)`,
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				c.Err(errors.New("missing source file"))
 				return
 			}
 
-			srcName := c.Args[0]
-			docName, _ := util.DocPathToName(srcName)
+			// Parse flags using pflag
+			flags := pflag.NewFlagSet("put", pflag.ContinueOnError)
+			flags.SetOutput(nil) // Suppress pflag's error output, we'll handle it
 
+			force := flags.Bool("force", false, "overwrite existing file")
+			contentOnly := flags.Bool("content-only", false, "replace PDF content only")
+			coverpage := flags.String("coverpage", "", "set coverpage (0 or 1)")
+
+			if err := flags.Parse(c.Args); err != nil {
+				c.Err(err)
+				return
+			}
+
+			args := flags.Args()
+			if len(args) == 0 {
+				c.Err(errors.New("missing source file"))
+				return
+			}
+
+			// Validate flags are mutually exclusive
+			if *force && *contentOnly {
+				c.Err(errors.New("--force and --content-only cannot be used together"))
+				return
+			}
+
+			// Parse coverpage flag
+			var coverpageFlag *int
+			if *coverpage != "" {
+				switch *coverpage {
+				case "0":
+					// Don't set coverpage (coverpageFlag remains nil)
+				case "1":
+					val := 0 // First page is 0 in the document metadata
+					coverpageFlag = &val
+				default:
+					c.Err(errors.New("--coverpage value must be 0 or 1"))
+					return
+				}
+			}
+
+			srcName := args[0]
+
+			// Handle --content-only mode (replace PDF content)
+			if *contentOnly {
+				// Validate that source file is a PDF
+				_, ext := util.DocPathToName(srcName)
+				if ext != "pdf" {
+					c.Err(errors.New("--content-only can only be used with PDF files"))
+					return
+				}
+
+				docName, _ := util.DocPathToName(srcName)
+				node := ctx.node
+				var err error
+
+				// Parse destination directory if provided
+				if len(args) == 2 {
+					node, err = ctx.api.Filetree().NodeByPath(args[1], ctx.node)
+					if err != nil || node.IsFile() {
+						c.Err(errors.New("directory doesn't exist"))
+						return
+					}
+				}
+
+				existingNode, err := ctx.api.Filetree().NodeByPath(docName, node)
+				if err != nil {
+					// Document doesn't exist, create new one
+					c.Printf("uploading: [%s]...", srcName)
+					dstDir := node.Id()
+					document, err := ctx.api.UploadDocument(dstDir, srcName, true, coverpageFlag)
+					if err != nil {
+						c.Err(fmt.Errorf("failed to upload file [%s]: %v", srcName, err))
+						return
+					}
+					c.Println("OK")
+					ctx.api.Filetree().AddDocument(document)
+					return
+				}
+
+				if existingNode.IsDirectory() {
+					c.Err(errors.New("cannot replace directory with file"))
+					return
+				}
+
+				c.Printf("replacing PDF content of [%s] with [%s]...", docName, srcName)
+				if err := ctx.api.ReplaceDocumentFile(existingNode.Document.ID, srcName, true); err != nil {
+					c.Err(fmt.Errorf("failed to replace content: %v", err))
+					return
+				}
+				c.Println("OK")
+				return
+			}
+
+			// Handle regular upload or --force mode
+			docName, _ := util.DocPathToName(srcName)
 			node := ctx.node
 			var err error
 
-			if len(c.Args) == 2 {
-				node, err = ctx.api.Filetree().NodeByPath(c.Args[1], ctx.node)
-
+			// Parse destination directory if provided
+			if len(args) == 2 {
+				node, err = ctx.api.Filetree().NodeByPath(args[1], ctx.node)
 				if err != nil || node.IsFile() {
 					c.Err(errors.New("directory doesn't exist"))
 					return
 				}
 			}
 
-			_, err = ctx.api.Filetree().NodeByPath(docName, node)
-			//TODO: force flag and overwrite
+			// Check if file exists and handle --force
+			existingNode, err := ctx.api.Filetree().NodeByPath(docName, node)
 			if err == nil {
-				c.Err(errors.New("entry already exists"))
+				// File exists
+				if !*force {
+					c.Err(errors.New("entry already exists (use --force to recreate, --content-only to replace content)"))
+					return
+				}
+				// Use --force: completely replace document (delete old, upload new)
+				if existingNode.IsDirectory() {
+					c.Err(errors.New("cannot overwrite directory with file"))
+					return
+				}
+				c.Printf("replacing: [%s]...", srcName)
+
+				// Delete existing document
+				if err := ctx.api.DeleteEntry(existingNode, false, false); err != nil {
+					c.Err(fmt.Errorf("failed to delete existing file: %v", err))
+					return
+				}
+				ctx.api.Filetree().DeleteNode(existingNode)
+
+				// Upload new document
+				dstDir := node.Id()
+				document, err := ctx.api.UploadDocument(dstDir, srcName, true, coverpageFlag)
+				if err != nil {
+					c.Err(fmt.Errorf("failed to upload replacement file [%s]: %v", srcName, err))
+					return
+				}
+
+				c.Println("OK")
+				ctx.api.Filetree().AddDocument(document)
 				return
 			}
 
+			// File doesn't exist, upload new document
 			c.Printf("uploading: [%s]...", srcName)
-
 			dstDir := node.Id()
-
-			document, err := ctx.api.UploadDocument(dstDir, srcName, true)
+			document, err := ctx.api.UploadDocument(dstDir, srcName, true, coverpageFlag)
 
 			if err != nil {
-				c.Err(fmt.Errorf("Failed to upload file [%s] %v", srcName, err))
+				c.Err(fmt.Errorf("failed to upload file [%s] %v", srcName, err))
 				return
 			}
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -62,7 +62,6 @@ func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
 	shell.AddCmd(rmCmd(ctx))
 	shell.AddCmd(mvCmd(ctx))
 	shell.AddCmd(putCmd(ctx))
-	shell.AddCmd(updateCmd(ctx))
 	shell.AddCmd(mputCmd(ctx))
 	shell.AddCmd(versionCmd(ctx))
 	shell.AddCmd(statCmd(ctx))


### PR DESCRIPTION
Moving these to a single PR to avoid merge conflicts since I'm changing `put` behavior in both. If you'd rather them be separate, let me know.

This PR adds the following flags to `put`:
- `--force`
  - Completely replace an existing document (removes all annotations and metadata)
  - Effectively a delete and a create
  - Creates document if it doesn't exist
- `--content-only`
  - Replace only the PDF content while preserving annotations and metadata
  - Errors if type isn't pdf
  - Creates document if it doesn't exist
 - `--coverpage=1`
   - Sets document to use the first page as the cover instead of "last opened"
  
This is technically a breaking change for the `update` command introduced in c9ceed7, but as we're v0 and this command wasn't documented in the readme, I opted to remove it to make things cleaner.