### PR TITLE
add arm64 builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,6 +38,10 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -46,6 +50,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,29 +23,46 @@ jobs:
 
       - run: echo "VERSION=`echo $(git describe --tags)`" >> $GITHUB_ENV
 
-      - name: Build Linux binary
-        run: go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi .
-        
+      - name: Build Linux AMD64 binary
+        run: GOOS=linux GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-linux-amd64 .
 
-      - name: Create tar
-        run: tar czvf rmapi-linuxx86-64.tar.gz rmapi
+      - name: Build Linux ARM64 binary
+        run: GOOS=linux GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-linux-arm64 .
 
-      - name: Build MacOS binary
-        run:  GOOS=darwin go build -v -o rmapi .
+      - name: Create Linux AMD64 tar
+        run: tar czvf rmapi-linux-amd64.tar.gz rmapi-linux-amd64
 
-      - name: Create zip
-        run: zip rmapi-macosx.zip rmapi
+      - name: Create Linux ARM64 tar
+        run: tar czvf rmapi-linux-arm64.tar.gz rmapi-linux-arm64
 
-      - name: Build Windows binary
-        run:  GOOS=windows go build -v -o rmapi.exe .
+      - name: Build MacOS AMD64 binary
+        run: GOOS=darwin GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-darwin-amd64 .
 
-      - name: Create zip
-        run: zip rmapi-win64.zip rmapi.exe
+      - name: Build MacOS ARM64 binary
+        run: GOOS=darwin GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-darwin-arm64 .
+
+      - name: Create MacOS AMD64 zip
+        run: zip rmapi-darwin-amd64.zip rmapi-darwin-amd64
+
+      - name: Create MacOS ARM64 zip
+        run: zip rmapi-darwin-arm64.zip rmapi-darwin-arm64
+
+      - name: Build Windows AMD64 binary
+        run: GOOS=windows GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-windows-amd64.exe .
+
+      - name: Build Windows ARM64 binary
+        run: GOOS=windows GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-windows-arm64.exe .
+
+      - name: Create Windows AMD64 zip
+        run: zip rmapi-windows-amd64.zip rmapi-windows-amd64.exe
+
+      - name: Create Windows ARM64 zip
+        run: zip rmapi-windows-arm64.zip rmapi-windows-arm64.exe
 
       - name: Release
         uses: docker://softprops/action-gh-release
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: rmapi-*
+          files: rmapi-*.zip rmapi-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,61 +8,84 @@ on:
 jobs:
 
   build:
-    name: Build
+    name: Build ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+            archive: tar.gz
+            name: linux-amd64
+          - goos: linux
+            goarch: arm64
+            ext: ""
+            archive: tar.gz
+            name: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+            archive: zip
+            name: macos-intel
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+            archive: zip
+            name: macos-arm64
+          - goos: windows
+            goarch: amd64
+            ext: .exe
+            archive: zip
+            name: win64
+          - goos: windows
+            goarch: arm64
+            ext: .exe
+            archive: zip
+            name: win-arm64
     steps:
-
       - name: Set up Go 1.23.1
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.1
-        id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - run: echo "VERSION=`echo $(git describe --tags)`" >> $GITHUB_ENV
 
-      - name: Build Linux AMD64 binary
-        run: GOOS=linux GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-linux-amd64 .
+      - name: Build binary
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi${{ matrix.ext }} .
 
-      - name: Build Linux ARM64 binary
-        run: GOOS=linux GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-linux-arm64 .
+      - name: Create archive
+        run: |
+          if [ "${{ matrix.archive }}" = "tar.gz" ]; then
+            tar czvf rmapi-${{ matrix.name }}.tar.gz rmapi${{ matrix.ext }}
+          else
+            zip rmapi-${{ matrix.name }}.zip rmapi${{ matrix.ext }}
+          fi
 
-      - name: Create Linux AMD64 tar
-        run: tar czvf rmapi-linux-amd64.tar.gz rmapi-linux-amd64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rmapi-${{ matrix.name }}
+          path: rmapi-${{ matrix.name }}.${{ matrix.archive }}
 
-      - name: Create Linux ARM64 tar
-        run: tar czvf rmapi-linux-arm64.tar.gz rmapi-linux-arm64
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
 
-      - name: Build MacOS AMD64 binary
-        run: GOOS=darwin GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-darwin-amd64 .
-
-      - name: Build MacOS ARM64 binary
-        run: GOOS=darwin GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-darwin-arm64 .
-
-      - name: Create MacOS AMD64 zip
-        run: zip rmapi-darwin-amd64.zip rmapi-darwin-amd64
-
-      - name: Create MacOS ARM64 zip
-        run: zip rmapi-darwin-arm64.zip rmapi-darwin-arm64
-
-      - name: Build Windows AMD64 binary
-        run: GOOS=windows GOARCH=amd64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-windows-amd64.exe .
-
-      - name: Build Windows ARM64 binary
-        run: GOOS=windows GOARCH=arm64 go build -v -ldflags "-X 'github.com/juruen/rmapi/version.Version=${{ env.VERSION }}'" -o rmapi-windows-arm64.exe .
-
-      - name: Create Windows AMD64 zip
-        run: zip rmapi-windows-amd64.zip rmapi-windows-amd64.exe
-
-      - name: Create Windows ARM64 zip
-        run: zip rmapi-windows-arm64.zip rmapi-windows-arm64.exe
+      - name: List downloaded files
+        run: find . -name "rmapi-*" -type f
 
       - name: Release
         uses: docker://softprops/action-gh-release
-        if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: rmapi-*.zip rmapi-*.tar.gz
+          files: "*/rmapi-*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM golang:alpine AS builder
-RUN apk add --no-cache git
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.6.1 AS xx
+
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+COPY --from=xx / /
+RUN apk add --no-cache git clang lld
+ARG TARGETPLATFORM
+RUN xx-apk add --no-cache musl-dev gcc
 
 WORKDIR /src
 COPY . .
-RUN CGO_ENABLED=0 go build
+RUN xx-go --wrap && \
+    CGO_ENABLED=0 xx-go build -ldflags="-s -w" -o rmapi .
 
 FROM alpine:latest
 


### PR DESCRIPTION
This PR adds arm64 builds for linux, macos, and windows, as well as a multi-arch Docker build including arm64 and amd64. I added a Github Actions matrix for the builds so that they run in parallel.