### PR TITLE
Filter template files from the ls command

### DIFF
--- a/model/document.go
+++ b/model/document.go
@@ -3,6 +3,7 @@ package model
 const (
 	DirectoryType = "CollectionType"
 	DocumentType  = "DocumentType"
+	TemplateType  = "TemplateType"
 )
 
 type Document struct {


### PR DESCRIPTION
By default, template files show up when you run the `ls` command. I added a filter that hides them by default, you can turn off the filter with the new `ls -s` flag.

Note, I have no experience with Go so if there is something weird about my code, do let me know!