### PR TITLE
Add --json flag for `ls` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ Start the shell by running `rmapi`
 Use `ls` to list the contents of the current directory. Entries are listed with `[d]` if they
 are directories, and `[f]` if they are files.
 
+Alternatively, pass the `--json` flag and receive output in JSON.
+
+```json
+[
+  {
+    "id": "981bece1-fd9d-499d-9b89-e5b5e2d1da34",
+    "name": "Journal",
+    "type": "DocumentType",
+    "version": 0,
+    "modifiedClient": "2025-09-21T15:53:05Z",
+    "currentPage": -1,
+    "parent": "2dccadc5-65a3-440d-86bc-da96df1f8324",
+    "isDirectory": false
+  },
+  {
+   "...": "..."
+  }
+]
+```
+
 ## Change current directory
 
 Use `cd` to change the current directory to any other directory in the hierarchy.

--- a/README.md
+++ b/README.md
@@ -99,22 +99,21 @@ are directories, and `[f]` if they are files.
 
 Alternatively, pass the `--json` flag and receive output in JSON.
 
-```json
-[
-  {
-    "id": "981bece1-fd9d-499d-9b89-e5b5e2d1da34",
-    "name": "Journal",
-    "type": "DocumentType",
-    "version": 0,
-    "modifiedClient": "2025-09-21T15:53:05Z",
-    "currentPage": -1,
-    "parent": "2dccadc5-65a3-440d-86bc-da96df1f8324",
-    "isDirectory": false
-  },
-  {
-   "...": "..."
-  }
-]
+```typescript
+interface Node {
+  id: string; // empty string for root node
+  name: string;
+  // TemplateType are downloaded reMarkable methods
+  // CollectionType refers to directories or the root node
+  // DocumentType is any PDF-document, Ebook or notebook    
+  type: "CollectionType" | "DocumentType" | "TemplateType";
+  version: number;         // Only relevant for type=DocumentType
+  modifiedClient: string;  // RFC3339Nano timestamp, empty for root
+  currentPage: number;     // 0-indexed, only meaningful for type=DocumentType
+  parent: string;          // parent ID, empty string for root children
+}
+
+type LsOutput = Node[];
 ```
 
 ## Change current directory

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func parseOfflineCommands(cmd []string) bool {
 
 func main() {
 	ni := flag.Bool("ni", false, "not interactive (prevents asking for code)")
+	jsonOutput := flag.Bool("json", false, "output in JSON format")
 	flag.Usage = func() {
 		fmt.Println(`
   help		detailed commands, but the user needs to be logged in
@@ -79,7 +80,7 @@ Offline Commands:
 		log.Error.Fatal("failed to build documents tree, last error: ", err)
 	}
 
-	err = shell.RunShell(ctx, userInfo, otherFlags)
+	err = shell.RunShell(ctx, userInfo, otherFlags, *jsonOutput)
 
 	if err != nil {
 		log.Error.Println("Error: ", err)

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -91,10 +91,9 @@ type NodeJSON struct {
 	Name           string `json:"name"`
 	Type           string `json:"type"`
 	Version        int    `json:"version"`
-	ModifiedClient string `json:"modifiedClient,omitempty"`
-	CurrentPage    int    `json:"currentPage,omitempty"`
-	Parent         string `json:"parent,omitempty"`
-	IsDirectory    bool   `json:"isDirectory"`
+	ModifiedClient string `json:"modifiedClient"`
+	CurrentPage    int    `json:"currentPage"`
+	Parent         string `json:"parent"`
 }
 
 func nodeToJSON(node *model.Node) NodeJSON {
@@ -106,7 +105,6 @@ func nodeToJSON(node *model.Node) NodeJSON {
 		ModifiedClient: node.Document.ModifiedClient,
 		CurrentPage:    node.Document.CurrentPage,
 		Parent:         node.Document.Parent,
-		IsDirectory:    node.IsDirectory(),
 	}
 }
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -15,6 +15,7 @@ type ShellCtxt struct {
 	path           string
 	useHiddenFiles bool
 	UserInfo       api.UserInfo
+	JSONOutput     bool
 }
 
 func (ctx *ShellCtxt) prompt() string {
@@ -41,7 +42,7 @@ func useHiddenFiles() bool {
 	return val != "0"
 }
 
-func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
+func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string, jsonOutput bool) error {
 	shell := ishell.New()
 	ctx := &ShellCtxt{
 		node:           apiCtx.Filetree().Root(),
@@ -49,6 +50,7 @@ func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
 		path:           apiCtx.Filetree().Root().Name(),
 		useHiddenFiles: useHiddenFiles(),
 		UserInfo:       *userInfo,
+		JSONOutput:     jsonOutput,
 	}
 
 	shell.SetPrompt(ctx.prompt())


### PR DESCRIPTION
I'm interested in making `rmapi` more amenable to programmatic consumption, the hardest command to work with by far is the `ls` command. This PR adds JSON output to the `ls` command.

I think it would be nice to add JSON output support to other commands as well, and to error messages especially to make it much easier to work with rmapi as a consuming library, I think this is a god first step.

I also updated the readme with info on the output type for the `ls` command.

Note: I'm not particularly well-versed with Go, I have used Claude to help me create this PR. I did write the documentation myself, test the commands and reviewed the code by hand, it's not pure vibe-coding.