### PR TITLE
Make starred property and tags available

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ Start the shell by running `rmapi`
 Use `ls` to list the contents of the current directory. Entries are listed with `[d]` if they
 are directories, and `[f]` if they are files.
 
+Alternatively, pass the `--json` flag and receive output in JSON.
+
+```json
+[
+  {
+    "id": "981bece1-fd9d-499d-9b89-e5b5e2d1da34",
+    "name": "Journal",
+    "type": "DocumentType",
+    "version": 0,
+    "modifiedClient": "2025-09-21T15:53:05Z",
+    "currentPage": -1,
+    "parent": "2dccadc5-65a3-440d-86bc-da96df1f8324",
+    "isDirectory": false
+  },
+  {
+   "...": "..."
+  }
+]
+```
+
 ## Change current directory
 
 Use `cd` to change the current directory to any other directory in the hierarchy.

--- a/README.md
+++ b/README.md
@@ -122,16 +122,48 @@ Use `cd` to change the current directory to any other directory in the hierarchy
 
 ## Find a file
 
-The command  `find` takes one or two arguments.
+The find command can be used to search through all of your reMarkable files recursively.
 
-If only the first argument is passed, all entries from that point are printed recursively.
+The first argument is the directory, and the second argument is your search query.
 
-When the second argument is also passed, a regexp is expected, and only those entries that match the regexp are printed.
+The search query is optional, when left out, the command will list files recursively.
 
-Golang standard regexps are used. For instance, to make the regexp case insensitve you can do:
+### Find examples
 
-```
-find . (?i)foo
+```bash
+# Find all starred files
+find --starred
+
+# Find starred files in the root directory
+find --starred /
+
+# Find files with the "read-later" tag in the current directory or below (recursively)
+find --tag="read-later" .
+
+# Searching is performed using standard Go regular expressions
+# Find files using a regular expression, for example when you have a particular format for diary files
+find / "Diary-.*"
+# For example, if you date your journals like this "Journal-DD-MM-YYYY", you can search for all journals in 2024 using
+find / "Journal-..-..-2024"
+# Or just search for all files with 2024 in the filename
+find / ".*2024.*"
+# If you want to search ignore character casing, you can do that as follows:
+find / "(?!i)case_insensitive_search"
+
+# Find files with either "Work" or "Personal" tag
+find --tag="Work" --tag="Personal"
+
+# Find starred files with a specific tag
+find --starred --tag="Important"
+
+# Combine with regexp search
+find --tag="Projects/2024" . ".*report.*"
+
+# Tags can contain special characters like /, \, ", etc.
+# Just quote them as you would any shell argument
+find --tag="Work/Projects" --tag="tag,with,comma"
+# This tag contains a double quote, you can escape it using \"
+find --tag="tag-\"with-double-quote"
 ```
 
 ## Upload a file

--- a/README.md
+++ b/README.md
@@ -99,22 +99,21 @@ are directories, and `[f]` if they are files.
 
 Alternatively, pass the `--json` flag and receive output in JSON.
 
-```json
-[
-  {
-    "id": "981bece1-fd9d-499d-9b89-e5b5e2d1da34",
-    "name": "Journal",
-    "type": "DocumentType",
-    "version": 0,
-    "modifiedClient": "2025-09-21T15:53:05Z",
-    "currentPage": -1,
-    "parent": "2dccadc5-65a3-440d-86bc-da96df1f8324",
-    "isDirectory": false
-  },
-  {
-   "...": "..."
-  }
-]
+```typescript
+interface Node {
+  id: string; // empty string for root node
+  name: string;
+  // TemplateType are downloaded reMarkable methods
+  // CollectionType refers to directories or the root node
+  // DocumentType is any PDF-document, Ebook or notebook    
+  type: "CollectionType" | "DocumentType" | "TemplateType";
+  version: number;         // Only relevant for type=DocumentType
+  modifiedClient: string;  // RFC3339Nano timestamp, empty for root
+  currentPage: number;     // 0-indexed, only meaningful for type=DocumentType
+  parent: string;          // parent ID, empty string for root children
+}
+
+type LsOutput = Node[];
 ```
 
 ## Change current directory

--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ Use `cd` to change the current directory to any other directory in the hierarchy
 
 ## Find a file
 
-The find command can be used to search through all of your reMarkable files recursively.
-
+The find command can be used to search through all of your reMarkable files recursively. 
 The first argument is the directory, and the second argument is your search query.
-
 The search query is optional, when left out, the command will list files recursively.
+
+You can find files with a particular tag using the `--tag` parameter, and filter for starred files using the `--starred` parameter.
+
+See the examples below:
 
 ### Find examples
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ interface Node {
   modifiedClient: string;  // RFC3339Nano timestamp, empty for root
   currentPage: number;     // 0-indexed, only meaningful for type=DocumentType
   parent: string;          // parent ID, empty string for root children
+  tags: string[];          // A list of tags. Note, this does -not- include per-page tags. Also works for directories
+  starred: boolean;        // Whether this item is starred or not. Also works for directories.
 }
 
 type LsOutput = Node[];
@@ -122,13 +124,15 @@ Use `cd` to change the current directory to any other directory in the hierarchy
 
 ## Find a file
 
+
 The find command can be used to search through all of your reMarkable files recursively. 
 The first argument is the directory, and the second argument is your search query.
 The search query is optional, when left out, the command will list files recursively.
 
-You can find files with a particular tag using the `--tag` parameter, and filter for starred files using the `--starred` parameter.
-
-See the examples below:
+- Flags:
+  - `--tag=<string>` only show files that include this tag. You can supply multiple tag parameters
+  - `--starred` if supplied, only show starred files
+  - `--json` show output in JSON, see the `ls` documentation for more detail
 
 ### Find examples
 

--- a/api/sync15/blobdoc.go
+++ b/api/sync15/blobdoc.go
@@ -243,6 +243,7 @@ func (d *BlobDoc) ToDocument() *model.Document {
 		Parent:         d.Metadata.Parent,
 		Type:           d.Metadata.CollectionType,
 		CurrentPage:    d.Metadata.LastOpenedPage,
+		Starred:        d.Metadata.Pinned,
 		ModifiedClient: lastModified,
 	}
 }

--- a/archive/file.go
+++ b/archive/file.go
@@ -45,7 +45,7 @@ func NewZip() *Zip {
 		PageCount:      0,
 		Pages:          []string{},
 		TextScale:      1,
-		Transform: Transform{
+		Transform: &Transform{
 			M11: 1,
 			M12: 0,
 			M13: 0,
@@ -87,6 +87,19 @@ type Layer struct {
 	Name string `json:"name"`
 }
 
+// Tag represents a document-level tag with timestamp
+type Tag struct {
+	Name      string `json:"name"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// PageTag represents a page-level tag with page ID and timestamp
+type PageTag struct {
+	Name      string `json:"name"`
+	PageID    string `json:"pageId"`
+	Timestamp int64  `json:"timestamp"`
+}
+
 // Content represents the structure of a .content json file.
 type Content struct {
 	DummyDocument bool          `json:"dummyDocument"`
@@ -102,13 +115,14 @@ type Content struct {
 	Orientation string `json:"orientation"`
 	PageCount   int    `json:"pageCount"`
 	// Pages is a list of page IDs
-	Pages          []string `json:"pages"`
-	Tags           []string `json:"pageTags"`
-	RedirectionMap []int    `json:"redirectionPageMap"`
-	TextScale      int      `json:"textScale"`
-	CoverPageNumber *int    `json:"coverPageNumber,omitempty"`
+	Pages           []string  `json:"pages"`
+	PageTags        []PageTag `json:"pageTags"`
+	DocumentTags    []Tag     `json:"tags"`
+	RedirectionMap  []int     `json:"redirectionPageMap"`
+	TextScale       float64   `json:"textScale"`
+	CoverPageNumber *int      `json:"coverPageNumber,omitempty"`
 
-	Transform Transform `json:"transform"`
+	Transform *Transform `json:"-"`
 }
 
 // ExtraMetadata is a struct contained into a Content struct.

--- a/archive/zipdoc.go
+++ b/archive/zipdoc.go
@@ -193,7 +193,7 @@ func createZipContent(ext string, pageIDs []string, coverpage *int) (string, err
 		LineHeight:     -1,
 		Margins:        180,
 		TextScale:      1,
-		Transform: Transform{
+		Transform: &Transform{
 			M11: 1,
 			M12: 0,
 			M13: 0,
@@ -204,7 +204,7 @@ func createZipContent(ext string, pageIDs []string, coverpage *int) (string, err
 			M32: 0,
 			M33: 1,
 		},
-		Pages: pageIDs,
+		Pages:           pageIDs,
 		CoverPageNumber: coverpage,
 	}
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func parseOfflineCommands(cmd []string) bool {
 
 func main() {
 	ni := flag.Bool("ni", false, "not interactive (prevents asking for code)")
+	jsonOutput := flag.Bool("json", false, "output in JSON format")
 	flag.Usage = func() {
 		fmt.Println(`
   help		detailed commands, but the user needs to be logged in
@@ -79,7 +80,7 @@ Offline Commands:
 		log.Error.Fatal("failed to build documents tree, last error: ", err)
 	}
 
-	err = shell.RunShell(ctx, userInfo, otherFlags)
+	err = shell.RunShell(ctx, userInfo, otherFlags, *jsonOutput)
 
 	if err != nil {
 		log.Error.Println("Error: ", err)

--- a/model/document.go
+++ b/model/document.go
@@ -13,6 +13,7 @@ type Document struct {
 	ModifiedClient string
 	Type           string
 	CurrentPage    int
+	Starred        bool
 	Parent         string
 }
 

--- a/model/document.go
+++ b/model/document.go
@@ -15,6 +15,7 @@ type Document struct {
 	CurrentPage    int
 	Starred        bool
 	Parent         string
+	Tags           []string
 }
 
 type BlobRootStorageRequest struct {

--- a/shell/find.go
+++ b/shell/find.go
@@ -45,7 +45,6 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 			}
 			argRest := flagSet.Args()
 
-			// Check if --starred flag was actually set
 			starredFilterEnabled := false
 			flagSet.Visit(func(f *flag.Flag) {
 				if f.Name == "starred" {
@@ -83,7 +82,6 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 				}
 			}
 
-			// Collect matching nodes
 			var matchedNodes []*model.Node
 			var matchedPaths [][]string
 
@@ -96,7 +94,7 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 						}
 					}
 
-					// Filter by tags if specified (must have ANY of the tags - OR semantics)
+					// Filter by tags if specified - using OR semantics
 					if len(tags) > 0 && node.Document != nil {
 						nodeTags := node.Document.Tags
 						hasMatch := false
@@ -112,7 +110,6 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 							}
 						}
 						if !hasMatch {
-							// Doesn't have any of the required tags, skip this node
 							return false
 						}
 					}
@@ -124,7 +121,6 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 						return false
 					}
 
-					// Collect matching node
 					matchedNodes = append(matchedNodes, node)
 					matchedPaths = append(matchedPaths, path)
 
@@ -132,7 +128,6 @@ func findCmd(ctx *ShellCtxt) *ishell.Cmd {
 				},
 			})
 
-			// Output results
 			if ctx.JSONOutput {
 				if err := displayNodesJSON(c, matchedNodes); err != nil {
 					c.Err(err)

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -87,14 +87,15 @@ type LsOptions struct {
 }
 
 type NodeJSON struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	Type           string `json:"type"`
-	Version        int    `json:"version"`
-	ModifiedClient string `json:"modifiedClient"`
-	CurrentPage    int    `json:"currentPage"`
-	Starred        bool   `json:"starred"`
-	Parent         string `json:"parent"`
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Type           string   `json:"type"`
+	Version        int      `json:"version"`
+	ModifiedClient string   `json:"modifiedClient"`
+	CurrentPage    int      `json:"currentPage"`
+	Starred        bool     `json:"starred"`
+	Parent         string   `json:"parent"`
+	Tags           []string `json:"tags"`
 }
 
 func nodeToJSON(node *model.Node) NodeJSON {
@@ -107,6 +108,7 @@ func nodeToJSON(node *model.Node) NodeJSON {
 		CurrentPage:    node.Document.CurrentPage,
 		Starred:        node.Document.Starred,
 		Parent:         node.Document.Parent,
+		Tags:           node.Document.Tags,
 	}
 }
 

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -91,10 +91,9 @@ type NodeJSON struct {
 	Name           string `json:"name"`
 	Type           string `json:"type"`
 	Version        int    `json:"version"`
-	ModifiedClient string `json:"modifiedClient,omitempty"`
-	CurrentPage    int    `json:"currentPage,omitempty"`
-	Parent         string `json:"parent,omitempty"`
-	IsDirectory    bool   `json:"isDirectory"`
+	ModifiedClient string `json:"modifiedClient"`
+	CurrentPage    int    `json:"currentPage"`
+	Parent         string `json:"parent"`
 }
 
 func nodeToJSON(node *model.Node) NodeJSON {
@@ -106,7 +105,6 @@ func nodeToJSON(node *model.Node) NodeJSON {
 		ModifiedClient: node.Document.ModifiedClient,
 		CurrentPage:    node.Document.CurrentPage,
 		Parent:         node.Document.Parent,
-		IsDirectory:    node.IsDirectory(),
 	}
 }
 

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"encoding/json"
 	"sort"
 	"strings"
 	"time"
@@ -84,47 +83,6 @@ type LsOptions struct {
 	DirFirst      bool
 	ByTime        bool
 	ShowTemplates bool
-}
-
-type NodeJSON struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	Type           string   `json:"type"`
-	Version        int      `json:"version"`
-	ModifiedClient string   `json:"modifiedClient"`
-	CurrentPage    int      `json:"currentPage"`
-	Starred        bool     `json:"starred"`
-	Parent         string   `json:"parent"`
-	Tags           []string `json:"tags"`
-}
-
-func nodeToJSON(node *model.Node) NodeJSON {
-	return NodeJSON{
-		ID:             node.Document.ID,
-		Name:           node.Document.Name,
-		Type:           node.Document.Type,
-		Version:        node.Document.Version,
-		ModifiedClient: node.Document.ModifiedClient,
-		CurrentPage:    node.Document.CurrentPage,
-		Starred:        node.Document.Starred,
-		Parent:         node.Document.Parent,
-		Tags:           node.Document.Tags,
-	}
-}
-
-func displayNodesJSON(c *ishell.Context, nodes []*model.Node) error {
-	jsonNodes := make([]NodeJSON, len(nodes))
-	for i, node := range nodes {
-		jsonNodes[i] = nodeToJSON(node)
-	}
-
-	output, err := json.MarshalIndent(jsonNodes, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	c.Println(string(output))
-	return nil
 }
 
 func lsCmd(ctx *ShellCtxt) *ishell.Cmd {

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -93,6 +93,7 @@ type NodeJSON struct {
 	Version        int    `json:"version"`
 	ModifiedClient string `json:"modifiedClient"`
 	CurrentPage    int    `json:"currentPage"`
+	Starred        bool   `json:"starred"`
 	Parent         string `json:"parent"`
 }
 
@@ -104,6 +105,7 @@ func nodeToJSON(node *model.Node) NodeJSON {
 		Version:        node.Document.Version,
 		ModifiedClient: node.Document.ModifiedClient,
 		CurrentPage:    node.Document.CurrentPage,
+		Starred:        node.Document.Starred,
 		Parent:         node.Document.Parent,
 	}
 }

--- a/shell/output.go
+++ b/shell/output.go
@@ -1,0 +1,49 @@
+package shell
+
+import (
+	"encoding/json"
+
+	"github.com/abiosoft/ishell"
+	"github.com/juruen/rmapi/model"
+)
+
+type NodeJSON struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Type           string   `json:"type"`
+	Version        int      `json:"version"`
+	ModifiedClient string   `json:"modifiedClient"`
+	CurrentPage    int      `json:"currentPage"`
+	Starred        bool     `json:"starred"`
+	Parent         string   `json:"parent"`
+	Tags           []string `json:"tags"`
+}
+
+func nodeToJSON(node *model.Node) NodeJSON {
+	return NodeJSON{
+		ID:             node.Document.ID,
+		Name:           node.Document.Name,
+		Type:           node.Document.Type,
+		Version:        node.Document.Version,
+		ModifiedClient: node.Document.ModifiedClient,
+		CurrentPage:    node.Document.CurrentPage,
+		Starred:        node.Document.Starred,
+		Parent:         node.Document.Parent,
+		Tags:           node.Document.Tags,
+	}
+}
+
+func displayNodesJSON(c *ishell.Context, nodes []*model.Node) error {
+	jsonNodes := make([]NodeJSON, len(nodes))
+	for i, node := range nodes {
+		jsonNodes[i] = nodeToJSON(node)
+	}
+
+	output, err := json.MarshalIndent(jsonNodes, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	c.Println(string(output))
+	return nil
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -15,6 +15,7 @@ type ShellCtxt struct {
 	path           string
 	useHiddenFiles bool
 	UserInfo       api.UserInfo
+	JSONOutput     bool
 }
 
 func (ctx *ShellCtxt) prompt() string {
@@ -41,7 +42,7 @@ func useHiddenFiles() bool {
 	return val != "0"
 }
 
-func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
+func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string, jsonOutput bool) error {
 	shell := ishell.New()
 	ctx := &ShellCtxt{
 		node:           apiCtx.Filetree().Root(),
@@ -49,6 +50,7 @@ func RunShell(apiCtx api.ApiCtx, userInfo *api.UserInfo, args []string) error {
 		path:           apiCtx.Filetree().Root().Name(),
 		useHiddenFiles: useHiddenFiles(),
 		UserInfo:       *userInfo,
+		JSONOutput:     jsonOutput,
 	}
 
 	shell.SetPrompt(ctx.prompt())


### PR DESCRIPTION
Note: This PR builds on top of the previous PR #38

I've been wanting to add this for a while. You can add tags to reMarkable documents and since recently even to folders! Additionally, you can star (favorite/pin) a document or folder as well.

This data was never available in rmapi, but it is now!

## Deliberations

The star and tag data have never been available through rmapi, but this information _is_ available from the API.

The starred property was trivial to add, it was available in the `.metadata` file which was already processed by rmapi.

The tags weren't readily available yet, since they're part of the `.content` file.

The most notable impactful change is that the `ReadMetadata` function in `blobdoc.go` now also retrieves and parses (marshalls?) the `.content` file.

Retrieving the file can slow down rmapi a little bit, since it does mean rmapi will be retrieving one extra file per item. I noted that my "Bullet Journal" file had a .content file which was 180kB, this is a file with over 500 pages and lots of annotations. This is the largest file I personally saw. It didn't slow down syncing for me, but that's likely because I have a 1 gigabit ethernet connection at home.

I did encounter a couple parsing/marshalling errors while making this. I got rid of the Transform field for now since it's not used anywhere in the codebase - it was giving errors. Additionally, I've changed the `TextScale` from int to float, since I was getting float data in my reMarkable account.

I have only tested this with my own reMarkable account. With a couple hundred files including a bunch of legacy files back from the rM 1 era, I'm not getting any `.content` parsing warnings anymore.

## New features

- The `starred: bool` field is now available in the `Document` struct
- Tags `tags: string[]` field is now available in the `Document` struct
- `find` command improvements
  - Added the `--json` parameter to find
  - Improved the documentation for find with a deluge of examples
    - Note: These examples were written by hand. I've tested all of them carefully.
  - Added `--starred` and `--tag=` parameters to find
- `stat` command improvements
  - When `--json` is passed, shows the `starred` flag and the `tags` list
- `ls` command improvements
  - When `--json` is passed, shows the `starred` flag and the `tags` list