### PR TITLE
default to schema v4

### DIFF
--- a/api/sync15/tree.go
+++ b/api/sync15/tree.go
@@ -155,7 +155,7 @@ func (t *HashTree) IndexReader() (io.Reader, error) {
 
 	schemaVersion := t.SchemaVersion
 	if schemaVersion == "" {
-		schemaVersion = SchemaVersionV3
+		schemaVersion = SchemaVersionV4
 	}
 
 	if envSchema := os.Getenv("RMAPI_FORCE_SCHEMA_VERSION"); envSchema != "" {
@@ -230,7 +230,7 @@ func (t *HashTree) Remove(id string) error {
 func (t *HashTree) Rehash() error {
 	schemaVersion := t.SchemaVersion
 	if schemaVersion == "" {
-		schemaVersion = SchemaVersionV3
+		schemaVersion = SchemaVersionV4
 	}
 
 	if envSchema := os.Getenv("RMAPI_FORCE_SCHEMA_VERSION"); envSchema != "" {


### PR DESCRIPTION
After some user reports of 400s on PUTs, it looks like the rM cloud is no longer allowing any v3 root.docSchema files. 

This PR changes the default from v3 to v4 when SchemaVersion is unset in the cache. It retains the env `RMAPI_FORCE_SCHEMA_VERSION` to override if needed for old rmfakecloud versions, etc.

The only case this doesn't cover is if the cloud provides a v3 root, which I haven't caught it doing yet.