### PR TITLE
fix: unexpected 'rm-filename' http header 400 error (add .docSchema extension when fetching document index in Mirror - fixes issue #62)

### DIFF
--- a/api/sync15/blobdoc.go
+++ b/api/sync15/blobdoc.go
@@ -214,7 +214,7 @@ func (d *BlobDoc) LineWithSchema(schema string) string {
 // Mirror updates the document to be the same as the remote
 func (d *BlobDoc) Mirror(e *Entry, r RemoteStorage) error {
 	d.Entry = *e
-	entryIndex, err := r.GetReader(e.Hash, e.DocumentID)
+	entryIndex, err := r.GetReader(e.Hash, addExt(e.DocumentID, archive.DocSchemaExt))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
All operations that build the document tree fail with HTTP 400 and the message `{"message":"unexpected 'rm-filename' http header"}` since reMarkable updated their API.

The root cause: `BlobDoc.Mirror()` was fetching each document's index blob with `rm-filename: <uuid>`, but the API now requires `rm-filename: <uuid>.docSchema`.

One-line change - use `addExt(e.DocumentID, archive.DocSchemaExt)` when calling `GetReader`, consistent with how uploads already work throughout `apictx.go`.

Verified with `rmapi ls` and `rmapi put` against the live reMarkable cloud API (May 2026).

Fixes #62 